### PR TITLE
Bump version of create-pull-request to v6 in github actions

### DIFF
--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -36,7 +36,7 @@ jobs:
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ steps.generate-token.outputs.token }}
           commit-message: "PO files added."


### PR DESCRIPTION
This fix a [bug](https://github.com/peter-evans/create-pull-request/issues/2790) that occurs on PR creation when the "same" pull request already exist.

