### PR TITLE
Improve the debbugging

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -42,52 +42,98 @@ Additionally, this will setup `config.DEBUG` to `True` from the code perspective
 
 ### VSCode debug config
 
-As an example, here is a json configuration that can be added inside your local `.vscode/launch.py` to use the integrated debugger:
+To enable debugging inside VSCode, create a `.vscode/launch.json` file with:
 ```json
 {
-    "name": "debug",
-    "type": "debugpy",
-    "request": "attach",
-    "connect": {
-        "host": "localhost",
-        "port": 5678
-    },
-    "pathMappings": [
+    "configurations": [
         {
-            "localRoot": "${workspaceFolder}/src",
-            "remoteRoot": "/app"
+            "name": "debug",
+            "type": "debugpy",
+            "request": "attach",
+            "connect": {
+                "host": "localhost",
+                "port": 5678
+            },
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}/src",
+                    "remoteRoot": "/app"
+                }
+            ],
+            "preLaunchTask": "wait",
+            "postDebugTask": "restart"
         }
     ]
 }
 ```
 
-After you run the code in debug mode, click on the "play" icon inside VSCode to attach the debug console. You can then use breakpoints, etc.  
-To make the restart button actually restart the bot and not just re-attach the debugger, you can add pre&post tasks:
-```json
-"preLaunchTask": "bot up",
-"postDebugTask": "bot restart",
-```
-And in `.vscode/tasks.json`, add the tasks:
+And a `.vscode/tasks.json` file with:
 ```json
 {
-    "label": "bot up",
-    "type": "shell",
-    "presentation": {
-        "reveal": "silent"
-    },
-    "command": "docker compose -f compose.yml -f compose.debug.yml up -d",
-},
-{
-    "label": "bot restart",
-    "type": "shell",
-    "presentation": {
-        "reveal": "silent"
-    },
-    "command": "docker-compose restart mybot"
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "type": "shell",
+            "presentation": {
+                "focus": true,
+            },
+            "command": "docker-compose -f compose.yml -f compose.debug.yml build",
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "watch",
+            "type": "shell",
+            "isBackground": true,
+            "presentation": {
+                "focus": true,
+                "panel": "new",
+            },
+            "command": "docker-compose -f compose.yml -f compose.debug.yml watch",
+            "problemMatcher": []
+        },
+        {
+            "label": "down",
+            "type": "shell",
+            "presentation": {
+                "focus": true,
+            },
+            "command": "docker compose down",
+            "problemMatcher": []
+        },
+        {
+            "label": "restart",
+            "type": "shell",
+            "presentation": {
+                "reveal": "silent",
+                "panel": "dedicated",
+                "close": true
+            },
+            "command": "docker-compose -f compose.yml -f compose.debug.yml restart mybot",
+            "problemMatcher": []
+        },
+        {
+            "label": "wait",
+            "type": "shell",
+            "presentation": {
+                "reveal": "silent",
+                "panel": "dedicated",
+                "close": true
+            },
+            "command": "sleep 0.1",
+            "problemMatcher": []
+        }
+    ]
 }
 ```
 
-If the bot is executed with the up task, you should then use the `watch` command with `--no-up`.
+`restart` and `wait` tasks are used by the debug task. Waiting 0.1s is a little trick to avoid the debugger to close because debugpy isn't ready yet.  
+The other tasks aren't required, but you can run them from `Terminal > Run Task...` (and `Run Build Task...` for the build task)?
+
 More information here: https://code.visualstudio.com/docs/python/debugging
 
 ## Database revisions

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -131,10 +131,10 @@ And a `.vscode/tasks.json` file with:
 }
 ```
 
-`restart` and `wait` tasks are used by the debug task. Waiting 0.1s is a little trick to avoid the debugger to close because debugpy isn't ready yet.  
+The `restart` and `wait` tasks are used by the debug task. Waiting 0.1s is a little trick to avoid the debugger to close because debugpy isn't ready yet.  
 The other tasks aren't required, but you can run them from `Terminal > Run Task...` (and `Run Build Task...` for the build task).
 
-You have to run the `watch` command before debugging.
+You must run the `watch` command before debugging.
 
 More information here: https://code.visualstudio.com/docs/python/debugging
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -132,7 +132,9 @@ And a `.vscode/tasks.json` file with:
 ```
 
 `restart` and `wait` tasks are used by the debug task. Waiting 0.1s is a little trick to avoid the debugger to close because debugpy isn't ready yet.  
-The other tasks aren't required, but you can run them from `Terminal > Run Task...` (and `Run Build Task...` for the build task)?
+The other tasks aren't required, but you can run them from `Terminal > Run Task...` (and `Run Build Task...` for the build task).
+
+You have to run the `watch` command before debugging.
 
 More information here: https://code.visualstudio.com/docs/python/debugging
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,4 @@ FROM base as debug
 ENV DEBUG=1
 ENV LOG_LEVEL=DEBUG
 RUN pip install debugpy
-CMD ["/bin/sh", "-c", "alembic upgrade head && python -m debugpy --wait-for-client --listen 0.0.0.0:5678 ./main.py run -c ./config.toml"]
+CMD ["/bin/sh", "-c", "alembic upgrade head && python -Xfrozen_modules=off -m debugpy --wait-for-client --listen 0.0.0.0:5678 ./main.py run -c ./config.toml"]

--- a/compose.yml
+++ b/compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   mybot:
-    init: True
+    init: true
     image: airopi/mybot:stable
     build:
       dockerfile: ./Dockerfile

--- a/compose.yml
+++ b/compose.yml
@@ -2,6 +2,7 @@ version: '3'
 
 services:
   mybot:
+    init: True
     image: airopi/mybot:stable
     build:
       dockerfile: ./Dockerfile


### PR DESCRIPTION
- use init to run the bot on PID 1. This make the bot stop in less than a second, while it stop within 10s otherwise.
- update the debug config files for vscode, because I figured out why it wasn't working this way before (added a wait instruction)
